### PR TITLE
Add minimal test suite and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,16 @@
+name: Python Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q

--- a/gmail_utils.py
+++ b/gmail_utils.py
@@ -46,3 +46,9 @@ def get_inbox_table(service, max_results=100):
             'snippet': snippet
         })
     return out
+
+
+def list_user_label_names(service):
+    """Returneaza numele etichetelor create de utilizator."""
+    labels = service.users().labels().list(userId="me").execute().get("labels", [])
+    return [l["name"] for l in labels if l.get("type") == "user"]

--- a/tests/test_gmail_utils.py
+++ b/tests/test_gmail_utils.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules['googleapiclient.discovery'] = types.ModuleType('googleapiclient.discovery')
+sys.modules['googleapiclient.discovery'].build = lambda *a, **k: None
+
+google_mod = types.ModuleType('google')
+google_auth = types.ModuleType('google.auth')
+google_auth_transport = types.ModuleType('google.auth.transport')
+google_auth_transport_requests = types.ModuleType('google.auth.transport.requests')
+google_auth_transport_requests.Request = lambda *a, **k: None
+
+google_auth_transport.requests = google_auth_transport_requests
+google_auth.transport = google_auth_transport
+google_mod.auth = google_auth
+sys.modules['google'] = google_mod
+sys.modules['google.auth'] = google_auth
+sys.modules['google.auth.transport'] = google_auth_transport
+sys.modules['google.auth.transport.requests'] = google_auth_transport_requests
+import gmail_utils
+
+
+def test_list_user_label_names():
+    service = MagicMock()
+    users = service.users.return_value
+    labels = users.labels.return_value
+    labels.list.return_value.execute.return_value = {
+        'labels': [
+            {'id': '1', 'name': 'Personal', 'type': 'user'},
+            {'id': '2', 'name': 'SYSTEM', 'type': 'system'},
+            {'id': '3', 'name': 'Work', 'type': 'user'}
+        ]
+    }
+
+    result = gmail_utils.list_user_label_names(service)
+
+    labels.list.assert_called_once_with(userId='me')
+    assert result == ['Personal', 'Work']
+
+

--- a/tests/test_move_from_table.py
+++ b/tests/test_move_from_table.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Minimal pandas stub for tests
+class _DF:
+    def __init__(self, rows):
+        self._rows = [dict(r) for r in rows]
+
+    def copy(self):
+        return _DF(self._rows)
+
+    def iterrows(self):
+        for i, row in enumerate(self._rows):
+            yield i, row
+
+
+def _DataFrame(data):
+    if isinstance(data, _DF):
+        return data
+    return _DF(data)
+
+pd = types.SimpleNamespace(DataFrame=_DataFrame)
+sys.modules['pandas'] = pd
+
+from move_from_table import move_emails_from_table
+
+
+def test_move_emails_from_table_creates_and_moves():
+    service = MagicMock()
+    users = service.users.return_value
+    labels = users.labels.return_value
+    messages = users.messages.return_value
+
+    labels.list.return_value.execute.return_value = {
+        'labels': [
+            {'id': 'lbl1', 'name': 'Existing', 'type': 'user'}
+        ]
+    }
+    labels.create.return_value.execute.return_value = {'id': 'lbl2'}
+    messages.modify.return_value.execute.return_value = None
+
+    table = pd.DataFrame([
+        {'id': '111', 'label': 'Existing'},
+        {'id': '222', 'label': 'NewLabel'},
+        {'id': '', 'label': 'Existing'},
+        {'id': '333', 'label': ''}
+    ])
+
+    result = move_emails_from_table(service, table)
+
+    labels.create.assert_called_once_with(userId='me', body={'name': 'NewLabel'})
+    assert messages.modify.call_count == 2
+    messages.modify.assert_any_call(
+        userId='me', id='111',
+        body={'addLabelIds': ['lbl1'], 'removeLabelIds': ['INBOX']}
+    )
+    messages.modify.assert_any_call(
+        userId='me', id='222',
+        body={'addLabelIds': ['lbl2'], 'removeLabelIds': ['INBOX']}
+    )
+
+    assert '✅ Mutat: 111 -> Existing' in result
+    assert '✅ Mutat: 222 -> NewLabel' in result
+
+


### PR DESCRIPTION
## Summary
- extend `gmail_utils` with a function for listing user labels
- add tests for `list_user_label_names` and `move_emails_from_table`
- provide a GitHub Actions workflow running the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842802b4dec8320989902788df82b01