### PR TITLE
Enhance label graph interactivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@
 - **Import și mutare masivă** a mailurilor pe etichete, direct din fișierul XLSX
 - **Generare reguli automate** pentru etichete pe baza istoricului de emailuri
 - **Vizualizare grafică a regulilor** (relație label – expeditor) cu Plotly
+- **Grafic interactiv al regulilor** – click pe o etichetă pentru a deschide
+  subgraficul într-un tab nou
 - **Clasificare automată Inbox** cu Gemini LLM și reguli custom, cu editare manuală și mutare rapidă
 - **Editare ușoară a labelurilor** direct în tabel, cu autocomplete din labelurile existente
 - **Statistici și grafice interactive** (Plotly) privind distribuția mailurilor pe etichete
@@ -60,14 +62,23 @@ and access the Gradio interface.
     ```
 
 2.  **Instalează dependințele**
+    Colab are deja versiuni recente pentru majoritatea bibliotecilor.
+    Fișierul `requirements.txt` indică doar versiuni minime, astfel
+    instalarea nu va face downgrade și nu mai este necesară repornirea
+    sesiunii.
     ```bash
-    !pip install -r requirements.txt
+    !pip install -q -r requirements.txt
     ```
 
 3.  **Configurare Ngrok (pentru tunelare locală necesară OAuth2)**
     * Creează un cont gratuit pe [Ngrok](https://ngrok.com/).
     * Obține-ți `AUTHTOKEN` din dashboard-ul Ngrok.
     * Adaugă-l la variabilele de mediu în Colab:
+      ```python
+      import os
+      os.environ["NGROK_TOKEN"] = "tokenul_tău_aici"
+      os.environ["NGROK_HOSTNAME"] = "stable-xxxxx-xxxxx.ngrok-free.app"
+      ```
        
 4.  **Configurare Credențiale Google API (OAuth2)**
     * Accesează [Google Cloud Console](https://console.cloud.google.com/).
@@ -82,22 +93,26 @@ and access the Gradio interface.
 5.  **Configurare Google Gemini API Key**
     * Obține o cheie API pentru Google Gemini de la [Google AI Studio](https://aistudio.google.com/app/apikey).
     * Adaugă cheia API la variabilele de mediu în Colab:
+      ```python
+      import os
+      os.environ["GEMINI_API_KEY"] = "cheia_ta_api"
+      ```
     
-6.  **Rulează aplicația in Colab**
+6.  **Rulează aplicația în Colab**
     ```python
     !git clone https://github.com/pasatsanduadrian/MailManager.git
     %cd MailManager
-    
-    !pip install -r requirements.txt
-    
+
+    !pip install -q -r requirements.txt
+
     with open(".env", "w") as f:
         f.write("SECRET_KEY=random123\n")
-        f.write("GEMINI_API_KEY=tokenul_tău_aici\n")
-        f.write("NGROK_TOKEN=tokenul_tău_aici\n")
+        # Înlocuiește valorile de mai jos cu token-urile tale reale
+        f.write("GEMINI_API_KEY=cheia_ta_api\n")
+        f.write("NGROK_TOKEN=tokenul_tau_ngrok\n")
         f.write("NGROK_HOSTNAME=stable-xxxxx-xxxxx.ngrok-free.app\n")
-    
-    !python3 main.py
 
+    !python3 main.py
     ```
     După rulare, Colab îți va afișa un link public la care poți accesa interfața Gradio în browser.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-flask==2.3.2
-pyngrok==5.2.3
-google-auth==2.23.0
-google-auth-oauthlib==1.0.0
-google-api-python-client==2.100.0
-gradio==4.14.0
-pandas==1.5.3
-python-dotenv==1.0.0
-google-generativeai==0.2.2
-xlsxwriter==3.1.2
-plotly==5.15.0
-networkx==3.1
+flask>=2.3.2
+pyngrok>=5.2.3
+google-auth>=2.23.0
+google-auth-oauthlib>=1.0.0
+google-api-python-client>=2.100.0
+gradio>=4.14.0
+pandas>=1.5.3
+python-dotenv>=1.0.0
+google-generativeai>=0.2.2
+xlsxwriter>=3.1.2
+plotly>=5.15.0
+networkx>=3.1
 


### PR DESCRIPTION
## Summary
- support optional focus label for rules graph
- expose `/rules_graph` endpoint serving interactive Plotly graph
- store generated rules for reuse in the interactive graph
- display a link to the interactive graph when rules are generated
- document the new interactive graph feature

## Testing
- `python3 -m py_compile main.py gmail_utils.py export_gmail_to_xlsx.py move_from_xlsx.py move_from_table.py gemini_utils.py gemini_labeler.py rules_from_labels.py rules_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68429c4ae97c8320ade59e48185ea942